### PR TITLE
Replace structopt::StructOpt with clap::Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0" }
 log = "0.4.8"
 futures = "0.3.16"
 tokio = { version = "1.13", features = ["signal"] }
-structopt = "0.3.26"
+clap = { version = "3.0", features = ["derive"] }
 # Calling RPC
 jsonrpc-core = "18.0"
 num-traits = "0.2.14"

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use crate::{
 	ChainInfo, FullBackendFor, FullClientFor, Node, ParachainInherentSproofProvider,
 	SharedParachainInherentProvider, SimnodeCli,
 };
+use clap::Parser;
 use futures::channel::mpsc;
 use manual_seal::{
 	consensus::{aura::AuraConsensusDataProvider, timestamp::SlotTimestampProvider},
@@ -53,7 +54,6 @@ use std::{
 	str::FromStr,
 	sync::{Arc, Mutex},
 };
-use structopt::StructOpt;
 
 /// Arguments to pass to the `create_rpc_io_handler`
 pub struct RpcHandlerArgs<C: ChainInfo, SC>
@@ -346,7 +346,7 @@ where
 {
 	let tokio_runtime = build_runtime()?;
 	// parse cli args
-	let cli = <<<C as ChainInfo>::Cli as SimnodeCli>::SubstrateCli as StructOpt>::from_args();
+	let cli = <<<C as ChainInfo>::Cli as SimnodeCli>::SubstrateCli as Parser>::parse();
 	let cli_config = <C as ChainInfo>::Cli::cli_config(&cli);
 
 	// set up logging
@@ -401,7 +401,7 @@ where
 {
 	let tokio_runtime = build_runtime()?;
 	// parse cli args
-	let cli = <<<C as ChainInfo>::Cli as SimnodeCli>::SubstrateCli as StructOpt>::from_args();
+	let cli = <<<C as ChainInfo>::Cli as SimnodeCli>::SubstrateCli as Parser>::parse();
 	let cli_config = <C as ChainInfo>::Cli::cli_config(&cli);
 
 	// set up logging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 
 //! ### substrate-simnode
 
-use structopt::StructOpt;
+use clap::Parser;
 use sc_cli::{CliConfiguration, SubstrateCli};
 use sc_consensus::BlockImport;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
@@ -41,9 +41,9 @@ pub use sproof::*;
 
 /// Type alias for [`sc_service::TFullClient`]
 pub type FullClientFor<C> = TFullClient<
-    <C as ChainInfo>::Block,
-    <C as ChainInfo>::RuntimeApi,
-    NativeElseWasmExecutor<<C as ChainInfo>::ExecutorDispatch>,
+	<C as ChainInfo>::Block,
+	<C as ChainInfo>::RuntimeApi,
+	NativeElseWasmExecutor<<C as ChainInfo>::ExecutorDispatch>,
 >;
 
 /// Type alias for [`sc_service::TFullBackend`]
@@ -51,73 +51,73 @@ pub type FullBackendFor<C> = TFullBackend<<C as ChainInfo>::Block>;
 
 /// Type alias for [`sc_transaction_pool_api::TransactionPool`]
 type TransactionPoolFor<T> = Arc<
-    dyn TransactionPool<
-        Block=<T as ChainInfo>::Block,
-        Hash=<<T as ChainInfo>::Block as BlockT>::Hash,
-        Error=sc_transaction_pool::error::Error,
-        InPoolTransaction=sc_transaction_pool::Transaction<
-            <<T as ChainInfo>::Block as BlockT>::Hash,
-            <<T as ChainInfo>::Block as BlockT>::Extrinsic,
-        >,
-    >,
+	dyn TransactionPool<
+		Block = <T as ChainInfo>::Block,
+		Hash = <<T as ChainInfo>::Block as BlockT>::Hash,
+		Error = sc_transaction_pool::error::Error,
+		InPoolTransaction = sc_transaction_pool::Transaction<
+			<<T as ChainInfo>::Block as BlockT>::Hash,
+			<<T as ChainInfo>::Block as BlockT>::Extrinsic,
+		>,
+	>,
 >;
 
 /// Wrapper trait for concrete type required by this testing framework.
 pub trait ChainInfo: Sized {
-    /// Opaque block type
-    type Block: BlockT;
+	/// Opaque block type
+	type Block: BlockT;
 
-    /// ExecutorDispatch dispatch type
-    type ExecutorDispatch: NativeExecutionDispatch + 'static;
+	/// ExecutorDispatch dispatch type
+	type ExecutorDispatch: NativeExecutionDispatch + 'static;
 
-    /// Runtime
-    type Runtime: frame_system::Config;
+	/// Runtime
+	type Runtime: frame_system::Config;
 
-    /// RuntimeApi
-    type RuntimeApi: Send + Sync + 'static + ConstructRuntimeApi<Self::Block, FullClientFor<Self>>;
+	/// RuntimeApi
+	type RuntimeApi: Send + Sync + 'static + ConstructRuntimeApi<Self::Block, FullClientFor<Self>>;
 
-    /// select chain type.
-    type SelectChain: SelectChain<Self::Block> + 'static;
+	/// select chain type.
+	type SelectChain: SelectChain<Self::Block> + 'static;
 
-    /// Block import type.
-    type BlockImport: Send
-    + Sync
-    + Clone
-    + BlockImport<
-        Self::Block,
-        Error=sp_consensus::Error,
-        Transaction=TransactionFor<FullClientFor<Self>, Self::Block>,
-    > + 'static;
+	/// Block import type.
+	type BlockImport: Send
+		+ Sync
+		+ Clone
+		+ BlockImport<
+			Self::Block,
+			Error = sp_consensus::Error,
+			Transaction = TransactionFor<FullClientFor<Self>, Self::Block>,
+		> + 'static;
 
-    /// The inherent data providers.
-    type InherentDataProviders: InherentDataProvider + 'static;
+	/// The inherent data providers.
+	type InherentDataProviders: InherentDataProvider + 'static;
 
-    /// Cli utilities
-    type Cli: SimnodeCli;
+	/// Cli utilities
+	type Cli: SimnodeCli;
 
-    /// Should return the json rpc Iohandler
-    fn create_rpc_io_handler<SC>(
-        deps: RpcHandlerArgs<Self, SC>,
-    ) -> jsonrpc_core::MetaIoHandler<sc_rpc::Metadata>
-        where
-            <<Self as ChainInfo>::RuntimeApi as ConstructRuntimeApi<
-                Self::Block,
-                FullClientFor<Self>,
-            >>::RuntimeApi: sp_api::Core<Self::Block>
-            + sp_transaction_pool::runtime_api::TaggedTransactionQueue<Self::Block>;
+	/// Should return the json rpc Iohandler
+	fn create_rpc_io_handler<SC>(
+		deps: RpcHandlerArgs<Self, SC>,
+	) -> jsonrpc_core::MetaIoHandler<sc_rpc::Metadata>
+	where
+		<<Self as ChainInfo>::RuntimeApi as ConstructRuntimeApi<
+			Self::Block,
+			FullClientFor<Self>,
+		>>::RuntimeApi: sp_api::Core<Self::Block>
+			+ sp_transaction_pool::runtime_api::TaggedTransactionQueue<Self::Block>;
 }
 
 /// Cli Extension trait for simnode
 pub trait SimnodeCli {
-    /// type that implements [`CliConfiguration`]
-    type CliConfig: CliConfiguration;
+	/// type that implements [`CliConfiguration`]
+	type CliConfig: CliConfiguration;
 
-    /// type that implements [`SubstrateCli`]
-    type SubstrateCli: StructOpt + SubstrateCli + Sized;
+	/// type that implements [`SubstrateCli`]
+	type SubstrateCli: Parser + SubstrateCli + Sized;
 
-    /// get a reference to [`CliConfiguration`]
-    fn cli_config(cli: &Self::SubstrateCli) -> &Self::CliConfig;
+	/// get a reference to [`CliConfiguration`]
+	fn cli_config(cli: &Self::SubstrateCli) -> &Self::CliConfig;
 
-    /// get logging filters
-    fn log_filters(cli_config: &Self::CliConfig) -> Result<String, sc_cli::Error>;
+	/// get logging filters
+	fn log_filters(cli_config: &Self::CliConfig) -> Result<String, sc_cli::Error>;
 }


### PR DESCRIPTION
Substrate  polkadot-v0.9.17 uses clap instead of structopt now