### PR TITLE
Fix bug in validation data

### DIFF
--- a/src/sproof.rs
+++ b/src/sproof.rs
@@ -75,7 +75,7 @@ where
 		ParachainInherentData {
 			validation_data: PersistedValidationData {
 				parent_head: header.into(),
-				relay_parent_number: info.best_number.as_() * 100,
+				relay_parent_number: info.best_number.as_() + 100,
 				relay_parent_storage_root: state_root,
 				max_pov_size: 15 * 1024 * 1024,
 			},


### PR DESCRIPTION
Using multiplication to generate the new relay chain block causes an error in set_validation_data check because it could cause both previous and current relaychain blocks to be zero in a situation where the best number was initially zero.