### PR TITLE
polkadot 2606.0.0 upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,20 +25,17 @@ scale-info = { version = "2.1.1", default-features = false, features = [
     "derive",
 ] }
 jsonrpsee = "0.24"
-polkadot-sdk = { version = "2604.2.0", default-features = false }
+polkadot-sdk = { version = "2606.0.0", default-features = false }
 
 # crates which cannot be used from polkadot-sdk
-sp-core = { version = "41.0.0", default-features = false }
-sp-runtime-interface = { version = "35.0.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.28.0", default-features = false }
-substrate-wasm-builder = "33.0.0"
-sc-service = "0.59.0"
-sc-network-sync = "0.56.1"
-sc-tracing = "46.0.0"
+sp-core = { version = "43.0.0", default-features = false }
+sp-runtime-interface = { version = "37.0.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.29.0", default-features = false }
+substrate-wasm-builder = "34.0.0"
+sc-service = "0.60.0"
+sc-network-sync = "0.57.0"
+sc-tracing = "47.0.0"
 
 # local crates
-simnode-runtime-api = { path = "./runtime-api", version = "2604.0.0", default-features = false }
-sc-simnode = { path = "./simnode", version = "2604.0.0" }
-
-[patch.crates-io]
-core2 = { git = "https://github.com/technocreatives/core2", rev = "545e84bcb0f235b12e21351e0c69767958efe2a7" }
+simnode-runtime-api = { path = "./runtime-api", version = "2606.0.0", default-features = false }
+sc-simnode = { path = "./simnode", version = "2606.0.0" }

--- a/examples/parachain/runtime/src/lib.rs
+++ b/examples/parachain/runtime/src/lib.rs
@@ -391,6 +391,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type RelayParentOffset = ConstU32<0>;
+	type SchedulingSignatureVerifier = ();
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<

--- a/runtime-api/Cargo.toml
+++ b/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simnode-runtime-api"
-version = "2604.0.0"
+version = "2606.0.0"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/simnode/Cargo.toml
+++ b/simnode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-simnode"
-version = "2604.0.0"
+version = "2606.0.0"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Due to the issue with the core2 dependency getting yanked off crates.io, upgrade to polkadot 26.0.0 is the ideal so as to enable us to publish Simnode easily.